### PR TITLE
ghi-4 Fix : Add "\n" after split

### DIFF
--- a/example/hello_world/main.rb
+++ b/example/hello_world/main.rb
@@ -6,7 +6,7 @@ require './lib/analyzer_core'
 core = SheepAst::AnalyzerCore.new
 
 core.config_tok do |tok|
-  tok.use_split_rule { ' ' }
+  tok.use_split_rule { tok.split_space_only }
 end
 
 core.config_ast('default.main') do |_ast, syn|

--- a/lib/analyzer_core.rb
+++ b/lib/analyzer_core.rb
@@ -82,9 +82,10 @@ module SheepAst
       end
     end
 
-    sig { params(expr: String).void }
+    sig { params(expr: String).returns(AnalyzerCore) }
     def <<(expr)
       analyze_expr(expr)
+      return self
     end
 
     sig { params(expr: String).void }

--- a/lib/tokenizer.rb
+++ b/lib/tokenizer.rb
@@ -128,6 +128,11 @@ module SheepAst
       end
     end
 
+    sig { returns Regexp }
+    def split_space_only
+      / |([\t\r\n\f])/
+    end
+
     private
 
     sig { params(line: String).returns(T::Array[String]) }
@@ -136,9 +141,9 @@ module SheepAst
         test = line.scan(/\w+|\W/)
       else
         test = line.split(@split.call)
-        # split erase "\n" so added here
-        test << "\n"
       end
+
+      test.reject!(&:empty?)
       if test.respond_to? :each
         # no process
       elsif test.nil?

--- a/lib/tokenizer.rb
+++ b/lib/tokenizer.rb
@@ -136,6 +136,8 @@ module SheepAst
         test = line.scan(/\w+|\W/)
       else
         test = line.split(@split.call)
+        # split erase "\n" so added here
+        test << "\n"
       end
       if test.respond_to? :each
         # no process

--- a/spec/tokenizer_spec.rb
+++ b/spec/tokenizer_spec.rb
@@ -76,15 +76,23 @@ abc def
     tok.dump(:ldebug)
   end
   it 'can use split rule' do
-    tok.use_split_rule { ' ' }
+    tok.use_split_rule { tok.split_space_only }
     buf, _max_line = tok << 'abc.a.a. 10.10.200.2/32'
     expect(buf).to eq([['abc.a.a.', '10.10.200.2/32']])
   end
   it 'can use split rule2' do
     buf, _max_line = tok << 'Hello, world. Now 2020/12/14 1:43'
     # p buf
-    tok.use_split_rule { ' ' }
+    tok.use_split_rule { tok.split_space_only }
     buf, _max_line = tok << 'Hello, world. Now 2020/12/14 1:43'
+    # p buf
+  end
+  it 'can use split rule2' do
+    buf, _max_line = tok << 'Hello, world. Now 2020/12/14 1:43'
+    # p buf
+    tok.use_split_rule { tok.split_space_only }
+    buf, _max_line = tok << "Hello, world. Now 2020/12/14 1:43 \n Hello again"
+    expect(buf).to eq([["Hello,", "world.", "Now", "2020/12/14", "1:43", "\n"], ["Hello", "again"]])
     # p buf
   end
 end


### PR DESCRIPTION
Rub split function erase "\n" return code. So added after split.
fixed #4 