### PR TITLE
run-sheep-ast is added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [0.4.0] - 2020-01-14
 ### Added
 - Include API to Let object to handle include another files
+
 ### Changed
 - Bugfix [Not open Issue] : Condition Match unexpectedly push matched strings to matched stack at the condition match ended
 
@@ -16,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - repeat option
 - various redirect option
 - API documentation
+
 ### Changed
 - Breaking change: directory structure changed.
 
@@ -24,12 +26,14 @@ All notable changes to this project will be documented in this file.
 - DataStore object can handle multiple value tags
 - Matched expression can be edit at the matched timing by extract: x..y
 - E(:any) expression is added
+
 ### Changed
 - NEQ usage changed
 
 ## [0.2.0] - 2020-12-15
 ### Added
 - Added NEQ syntax for supporting multiple Action shared syntax chain
+
 ### Changed
 - Moved Gemfile dependency to gemspec
 

--- a/README.md
+++ b/README.md
@@ -110,3 +110,6 @@ Please clone this repository or install via gem. Following commands from top dir
 
 - Framework Design  
   https://yanei11.github.io/sheep_ast_pages/file.Framework.html
+
+- Change Log  
+  https://yanei11.github.io/sheep_ast_pages/file.CHANGELOG.html

--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,7 @@ end
 desc 'Making Yardoc to the SHEEP_DOC_DIR directory.'
 task 'doc' do
   sh "rm -rf  #{ENV['SHEEP_DOC_DIR']}"
-  sh "#{ENV['RBENV_COM']} bundle exec yardoc -m markdown --plugin sorbet -o #{ENV['SHEEP_DOC_DIR']} - README.md \
+  sh "#{ENV['RBENV_COM']} bundle exec yardoc -m markdown --plugin sorbet -o #{ENV['SHEEP_DOC_DIR']} - README.md CHANGELOG.md \
       INSTALL.md manual/*"
 end
 

--- a/bin/run-sheep-ast
+++ b/bin/run-sheep-ast
@@ -1,0 +1,45 @@
+#!/usr/bin/env ruby
+
+require 'bundler/setup'
+require 'sheep_ast'
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+prog = __FILE__.to_s.split('/').last
+
+option = SheepAst::AnalyzerCore.option_parse(ARGV)
+config_file = option[:r]
+
+if config_file.nil?
+  SheepAst::AnalyzerCore.usage
+  exit
+end
+
+puts
+
+if File.exist?(config_file)
+  load config_file
+else
+  puts "#{prog}> #{config_file} could not be found"
+end
+
+if defined? configure
+  puts "#{prog}> Do configure"
+  core = SheepAst::AnalyzerCore.new
+  configure(core)
+  if !ARGV.empty?
+    core.report(raise: false) {
+      puts "#{prog}> Do analyze"
+      core.analyze_file(ARGV) unless ARGV.empty?
+    }
+  else
+    puts "#{prog}> Files are not given to ARGV."
+  end
+end
+
+puts "#{prog}> Finish. Thank you."

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/example/include/main.rb
+++ b/example/include/main.rb
@@ -1,0 +1,57 @@
+# typed: false
+# frozen_string_literal: true
+# rubocop: disable all
+
+require 'sheep_ast'
+
+core = SheepAst::AnalyzerCore.new
+
+core.config_tok do |tok|
+  tok.add_token tok.cmp('#', 'include')
+  tok.add_token tok.cmp('/', '/')
+end
+
+core.sheep_dir_path_set(['spec/test_files/'])
+
+core.config_ast('always.ignore') do |ast, syn|
+  syn.within {
+    register_syntax('ignore', A(:na)) {
+      _SS(
+        _S << E(:e, ' '),
+        _S << E(:e, "\n"),
+        _S << E(:eof)
+      )
+    }
+  }
+end
+
+core.config_ast('default.main') do |ast, syn|
+  syn.within {
+    register_syntax('analyze') {
+      _SS(
+        _S << E(:e, '#include') << E(:enc, '<', '>') << A(:let, [:include, :_2]),
+        _S << E(:e, '#include') << E(:enc, '"', '"') << A(:let, [:include, :_2]),
+        _S << E(:e, 'struct') << E(:any) << E(:sc, '{', '}') << E(:e, ';') << A(:let,
+                                                                                [:show, {disable: true}],
+                                                                                [:record, :test_H, :_2, :_3]
+                                                                               )
+      )
+    }
+  }
+end
+
+core.config_ast('always.ignore2') do |ast, syn|
+  syn.within {
+    register_syntax('ignore', A(:na)) {
+      _SS(
+        _S << E(:e, 'int') << E(:e, 'main') << E(:sc, '(', ')') << E(:sc, '{', '}')
+      )
+    }
+  }
+end
+
+res = core.report(raise: false) { core.analyze_file(['spec/test_files/test1.cc']) }
+expect(res).to be true
+expect(core.data_store.value(:test_H)['Test1']).to eq(["{", "int", "a", ";", "int", "b", ";", "int", "c", ";", "}"])
+expect(core.data_store.value(:test_H)['Test2']).to eq(["{", "int", "i", ";", "int", "j", ";", "int", "k", ";", "}"])
+expect(core.data_store.value(:test_H)['Test3']).to eq(["{", "int", "x", ";", "int", "y", ";", "int", "z", ";", "}"])

--- a/example/protobuf2/configure.rb
+++ b/example/protobuf2/configure.rb
@@ -1,0 +1,106 @@
+# typed: ignore
+# frozen_string_literal: true
+
+#rubocop: disable all
+def configure(core)
+  template1 = 'example/protobuf/template_message.erb'
+  template2 = 'example/protobuf/template_enum.erb'
+  action1 = [:compile, template1, { dry_run: false }]
+  action2 = [:compile, template2, { dry_run: false }]
+  dry1 = false
+  dry2 = false
+
+  core.config_tok do |tok|
+  end
+
+  core.config_ast('always.ignore') do |_ast, syn|
+    syn.within {
+      register_syntax('analyze', A(:na)) {
+        _SS(
+          _S << E(:e, ' ')
+        )
+      }
+    }
+  end
+
+  core.config_ast('default.ignore_syntax') do |_ast, syn|
+    syn.within {
+      register_syntax('analyze') {
+        _SS(
+          _S << E(:e, 'syntax') << E(:e, '=') << E(:e, '"') << E(:e, 'proto2')\
+             << E(:e, '"') << E(:e, ';') << A(:let, [:show, { disable: true }]),
+          _S << E(:e, 'package') << E(:any) << E(:e, ';') << A(:let, [:show, { disable: true }])
+        )
+      }
+    }
+  end
+
+  core.config_ast('message.parser') do |_ast, syn|
+    syn.within {
+      register_syntax('analyze') {
+        _SS(
+          _S << E(:e, 'optional') << E(:any, { repeat: 4 }) << E(:e, ';')\
+                                  << A(
+                                    :let,
+                                    action1
+                                  ),
+          _S << E(:e, 'optional') << E(:any, { repeat: 4 }) << E(:e, '[')\
+                                  << E(:any, { repeat: 4 }) << E(:e, ';')\
+                                  << A(
+                                    :let,
+                                    action1
+                                  ),
+          _S << E(:e, 'repeated') << E(:any, { repeat: 4 }) << E(:e, ';')\
+                                  << A(
+                                    :let,
+                                    action1
+                                  ),
+          _S << E(:e, 'repeated') << E(:any, { repeat: 4 }) << E(:e, '[')\
+                                  << E(:any, { repeat: 4 }) << E(:e, ';')\
+                                  << A(
+                                    :let,
+                                    action1
+                                  )
+        )
+      }
+    }
+  end
+
+  core.config_ast('enum.parser') do |_ast, syn|
+    syn.within {
+      register_syntax('analyze') {
+        _SS(
+          _S << E(:any, { at_head: true }) << E(:any, { repeat: 2 }) << E(:e, ';')\
+             << A(
+               :let,
+               action2
+             )
+        )
+      }
+    }
+  end
+
+  core.config_ast('default.parse1') do |_ast, syn|
+    syn.within {
+      register_syntax('analyze') {
+        _SS(
+          _S << E(:e, 'message') << E(:any) << E(:sc, '{', '}') \
+             << A(:let, [:redirect, :_3, 2..-2, { dry_run: dry1, namespace: :_2, ast_include: ['default', 'message'] }]),
+          _S << E(:e, 'enum') << E(:any) << E(:sc, '{', '}') \
+             << A(:let, [:redirect, :_3, 2..-2, { dry_run: dry2, namespace: :_2, ast_include: ['enum'] }])
+        )
+      }
+    }
+  end
+
+  core.config_ast('always.continue') do |_ast, syn|
+    syn.within {
+      register_syntax('analyze', A(:na)) {
+        _SS(
+          _S << E(:e, "\n"),
+          _S << E(:eof)
+        )
+      }
+    }
+  end
+end

--- a/example/protobuf2/example.proto
+++ b/example/protobuf2/example.proto
@@ -1,0 +1,26 @@
+syntax = "proto2";
+
+package tutorial;
+
+message Person {
+  optional string name = 1;
+  optional int32 id = 2;
+  optional string email = 3;
+
+  enum PhoneType {
+    MOBILE = 0;
+    HOME = 1;
+    WORK = 2;
+  }
+
+  message PhoneNumber {
+    optional string number = 1;
+    optional PhoneType type = 2 [default = HOME];
+  }
+
+  repeated PhoneNumber phones = 4;
+}
+
+message AddressBook {
+  repeated Person people = 1;
+}

--- a/example/protobuf2/main.rb
+++ b/example/protobuf2/main.rb
@@ -1,0 +1,110 @@
+# typed: ignore
+# frozen_string_literal: true
+
+#rubocop: disable all
+def configure(core)
+  template1 = 'example/protobuf/template_message.erb'
+  template2 = 'example/protobuf/template_enum.erb'
+  action1 = [:compile, template1, { dry_run: false }]
+  action2 = [:compile, template2, { dry_run: false }]
+  dry1 = false
+  dry2 = false
+
+  core.config_tok do |tok|
+  end
+
+  core.config_ast('always.ignore') do |_ast, syn|
+    syn.within {
+      register_syntax('analyze', A(:na)) {
+        _SS(
+          _S << E(:e, ' ')
+        )
+      }
+    }
+  end
+
+  core.config_ast('default.ignore_syntax') do |_ast, syn|
+    syn.within {
+      register_syntax('analyze') {
+        _SS(
+          _S << E(:e, 'syntax') << E(:e, '=') << E(:e, '"') << E(:e, 'proto2')\
+             << E(:e, '"') << E(:e, ';') << A(:let, [:show, { disable: true }]),
+          _S << E(:e, 'package') << E(:any) << E(:e, ';') << A(:let, [:show, { disable: true }])
+        )
+      }
+    }
+  end
+
+  core.config_ast('message.parser') do |_ast, syn|
+    syn.within {
+      register_syntax('analyze') {
+        _SS(
+          _S << E(:e, 'optional') << E(:any, { repeat: 4 }) << E(:e, ';')\
+                                  << A(
+                                    :let,
+                                    action1
+                                  ),
+          _S << E(:e, 'optional') << E(:any, { repeat: 4 }) << E(:e, '[')\
+                                  << E(:any, { repeat: 4 }) << E(:e, ';')\
+                                  << A(
+                                    :let,
+                                    action1
+                                  ),
+          _S << E(:e, 'repeated') << E(:any, { repeat: 4 }) << E(:e, ';')\
+                                  << A(
+                                    :let,
+                                    action1
+                                  ),
+          _S << E(:e, 'repeated') << E(:any, { repeat: 4 }) << E(:e, '[')\
+                                  << E(:any, { repeat: 4 }) << E(:e, ';')\
+                                  << A(
+                                    :let,
+                                    action1
+                                  )
+        )
+      }
+    }
+  end
+
+  core.config_ast('enum.parser') do |_ast, syn|
+    syn.within {
+      register_syntax('analyze') {
+        _SS(
+          _S << E(:any, { at_head: true }) << E(:any, { repeat: 2 }) << E(:e, ';')\
+             << A(
+               :let,
+               action2
+             )
+        )
+      }
+    }
+  end
+
+  core.config_ast('default.parse1') do |_ast, syn|
+    syn.within {
+      register_syntax('analyze') {
+        _SS(
+          _S << E(:e, 'message') << E(:any) << E(:sc, '{', '}') \
+             << A(:let, [:redirect, :_3, 2..-2, { dry_run: dry1, namespace: :_2, ast_include: ['default', 'message'] }]),
+          _S << E(:e, 'enum') << E(:any) << E(:sc, '{', '}') \
+             << A(:let, [:redirect, :_3, 2..-2, { dry_run: dry2, namespace: :_2, ast_include: ['enum'] }])
+        )
+      }
+    }
+  end
+
+  core.config_ast('always.continue') do |_ast, syn|
+    syn.within {
+      register_syntax('analyze', A(:na)) {
+        _SS(
+          _S << E(:e, "\n"),
+          _S << E(:eof)
+        )
+      }
+    }
+  end
+
+  core.report(raise: false) {
+    core.analyze_file(['example/protobuf/example.proto'])
+  }
+end

--- a/example/protobuf2/template_enum.erb
+++ b/example/protobuf2/template_enum.erb
@@ -1,0 +1,3 @@
+<%# Output file name => !"example/protobuf/result".txt!  %>
+<% ns = namespace.empty? ? '' : namespace + '::'  %>
+<%= ns + data[:_1] %> : type = int, property = enum

--- a/example/protobuf2/template_message.erb
+++ b/example/protobuf2/template_message.erb
@@ -1,0 +1,4 @@
+<%# Output file name => !"example/protobuf/result".txt!  %>
+<% ns = namespace.empty? ? '' : namespace + '::'  %>
+<%= ns + data[:_3] %> : type = <%= data[:_2] %>, property = <%= data[:_1]  %>
+

--- a/lib/sheep_ast/match/match_base.rb
+++ b/lib/sheep_ast/match/match_base.rb
@@ -48,6 +48,9 @@ module SheepAst
     sig { returns(Integer) }
     attr_accessor :my_chain_num
 
+    sig { returns(T.nilable(Symbol)) }
+    attr_accessor :node_tag
+
     sig { params(name: String).void }
     def kind_name_set(name)
       @kind_name = name

--- a/lib/sheep_ast/node.rb
+++ b/lib/sheep_ast/node.rb
@@ -36,6 +36,9 @@ module SheepAst
     sig { returns(T.nilable(ActionBase)) }
     attr_reader :my_action
 
+    sig { returns(T.nilable(Integer)) }
+    attr_reader :my_chain_id
+
     sig { returns(NodeFactory) }
     attr_accessor :my_node_factory
 

--- a/lib/sheep_ast/tokenizer.rb
+++ b/lib/sheep_ast/tokenizer.rb
@@ -132,6 +132,11 @@ module SheepAst
       line_count = 0
       file_buf = []
       raw_buf = []
+
+      if !File.exist?(fpath)
+        application_error "#{fpath} is not found"
+      end
+
       File.open(fpath) do |f|
         f.each_line do |line|
           line_count += 1

--- a/manual/Framework.md
+++ b/manual/Framework.md
@@ -30,25 +30,25 @@ AnalyzerCore
   |->Syntax - SyntaxAlias
   | -------   ------------
   |
-  |-------------------------------------------------------------------
-  |                                                                  |
-  |-> FileManager                                                    |
-  |-> StageManager -> AstManager - Node <- NodeFactory               |
-                      ----------   |                                 |/
-                                   |- Match  <-  MatchFactory  <-|- FoF 
-                                   |  -----                      |
-                                   |    |-> ExactMatch           |
-                                   |    |-> RegexMatch           |
-                                   |    |-> ...                  |
-                                   |                             |
-                                   |- Action <-  ActionFactory <-|
-                                      ------
-                                        |-> NoAction
-                                        |-> Let
-                                             |- LetRedirect
-                                             |- LetReord
-                                             |- LetCompile
-                                             |- ...
+  |--------------------------------------------------------------------------------------
+  |                                                                                     |
+  |-> FileManager                                                                       |
+  |-> StageManager -> AstManager -> NodeFactory -> Node                                 |
+                      ----------                    |                                   |/
+                                                    |- XXXMatch  <- MatchFactory  <-|- FoF
+                                                    |  --------                     |
+                                                    |    |- ExactMatch              |
+                                                    |    |- RegexMatch              |
+                                                    |    |- ...                     |
+                                                    |                               |
+                                                    |- XXXAction <- ActionFactory <-|
+                                                       ---------
+                                                         |- NoAction
+                                                         |- Let
+                                                              |- LetRedirect
+                                                              |- LetReord
+                                                              |- LetCompile
+                                                              |- ...
 ```
 
 Followings are the information flow.
@@ -91,6 +91,9 @@ Action <- data
 
 You can trace flow by enabling log level of SHEEP_LOG environment variable like SHEEP_LOG=DEBUG.
 
+Sheep_ast has more function than just Match - Action.  
+Followings are highlight features provided by Framework.
+
 # Redirect and Namespace
 
 In {SheepAst::Let Let} object, there is redirect function.
@@ -110,3 +113,9 @@ With the function, it is possible to generate new file from matched data and tem
 In {SheepAst::Let Let} object, there is record function.
 
 This function allow user to record specified string. This function uses {SheepAst::DataStore DataStore} object. Please see the yard page for the usage.
+
+# Include Handler
+
+In {SheepAst::Let Let} object, there is include function.
+
+This function allows user to switch to analyze another file. For example, if there is `#include "xxx.hh"` strings while parsing, framework provides way to switch to analyze xxx.hh from the given paths.

--- a/sheep_ast.gemspec
+++ b/sheep_ast.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage 
-  spec.metadata["changelog_uri"] = spec.homepage
+  spec.metadata["changelog_uri"] = "https://yanei11.github.io/sheep_ast_pages/file.CHANGELOG.html"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
Added executable of run-sheep-ast.

```
Usage: run-sheep-ast [options] arg1, arg2, ...
    arg1, arg2, ... : specify files to parse.

Available options :
    -E array                         Specify directories for the files that should not be included
    -I array                         Specify directories for the include files
    -d                               Dump Debug information
    -r file                          Specify configuration ruby file
    -h, --help                       show usage
    -v, --version                    show version
```